### PR TITLE
[상품 리스트 전달 API 수정]

### DIFF
--- a/model/product_dao.py
+++ b/model/product_dao.py
@@ -183,6 +183,7 @@ class ProductDao:
             INNER JOIN product_info AS p_info ON p_info.product_id = :product_id
             INNER JOIN sellers AS s ON p_info.seller_id = s.id
             INNER JOIN seller_info AS s_info ON s_info.seller_id = s.id
+            WHERE p.id = :product_id
             ORDER BY p_info.created_at DESC 
             LIMIT 1
         """), {'product_id' : product_id}).fetchone()

--- a/run.py
+++ b/run.py
@@ -2,5 +2,5 @@ from app import create_app
 
 if __name__ == '__main__':
     app = create_app()
-    
-    app.run(host = '10.251.1.139', port = 5000, debug = True)
+
+    app.run(host = '10.251.1.153', port = 5000, debug = True)


### PR DESCRIPTION
- 에러 주석 해제
- 메인 카테고리 필터링 위한 조건문 수정
- 메인 카테고리 아이디가 5 또는 6 일때 상단 nav 에서 메인 카테고리로 들어왔을 때 보내는 데이터와 왼쪽nav 에서 전체를 눌렀을 때 보내는 데이터를 구분
- 상품 상세 정보 API 에 상품 아이디로 조건을 거는 WHERE 절 추가
- 베스트 상품, 추천 상품 리스트 조건 수정
- 5, 6 번 카테고리 특정 셀러의 상품 리스트 전달을 위해 조건 수정